### PR TITLE
removing battery margin <?.?.x>

### DIFF
--- a/src/PresentationalComponents/Battery/battery.scss
+++ b/src/PresentationalComponents/Battery/battery.scss
@@ -34,5 +34,3 @@
     path { fill: $ins-color--critical; }
   }
 }
-
-.ins-battery + .ins-battery { @include rem('margin-left', 10px); }

--- a/src/PresentationalComponents/Section/section.scss
+++ b/src/PresentationalComponents/Section/section.scss
@@ -11,7 +11,7 @@ section.ins-l-button-group {
 }
 
 section.ins-l-icon-group {
-  * + * { margin-left: 7.5px; }
+  * + * { margin-left: 10px; }
 }
 
 section.ins-l-icon-group__with-major {


### PR DESCRIPTION
Removes battery margin when used with another battery. If two batteries are used, they should be used in a `<Section type='icon-group'>`