### PR TITLE
fixing ordering of tooltip with donut-hole <?.?.x>

### DIFF
--- a/src/Charts/Donut/donut.scss
+++ b/src/Charts/Donut/donut.scss
@@ -26,18 +26,22 @@
     }
 }
 
-.ins-c-donut .c3-tooltip {
-    display: block;
-    background-color:#545454;
+.ins-c-donut .c3-tooltip-container{
     z-index: 3;
-    @include rem('padding', 10px 15px);
-    .name { font-weight: 700; }
-    td {
-        flex-direction: row;
-        font-size:13px;
-        color: #fff;
+    opacity: .9;
+    .c3-tooltip {
+        display: block;
+        background-color:#545454;
+        z-index: 3;
+        @include rem('padding', 10px 15px);
+        .name { font-weight: 700; }
+        td {
+            flex-direction: row;
+            font-size:13px;
+            color: #fff;
+        }
+        td + td { @include rem('padding-left', 20px); }
     }
-    td + td { @include rem('padding-left', 20px); }
 }
 
 // with-legend

--- a/src/Charts/Donut/donut.scss
+++ b/src/Charts/Donut/donut.scss
@@ -32,7 +32,6 @@
     .c3-tooltip {
         display: block;
         background-color:#545454;
-        z-index: 3;
         @include rem('padding', 10px 15px);
         .name { font-weight: 700; }
         td {


### PR DESCRIPTION
Before, the ordering of the donut hole came after the tooltip, so the donut hole numbers would be above. Putting a z-index of 3 on the donut will solve this issue as well as the problem with it not appearing over the Summary Chart in Advisor.