### PR TITLE
Adding widget attributes to charts, removing pageheader double import <?.?.x>

### DIFF
--- a/src/Charts/Donut/Donut.js
+++ b/src/Charts/Donut/Donut.js
@@ -129,7 +129,7 @@ class Donut extends Component {
         }
 
         return (
-            <div className={ wrapperClasses }>
+            <div className={ wrapperClasses } widget-type='InsightsDonut' widget-id={ this.props.identifier }>
                 <div className='ins-l-donut'>
                     <div id={ this.props.identifier } className={ donutClasses }></div>
                     <div className='ins-c-donut-hole'>

--- a/src/Charts/Gauge/Gauge.js
+++ b/src/Charts/Gauge/Gauge.js
@@ -87,7 +87,7 @@ class Gauge extends Component {
         );
 
         return (
-            <div id={ this.props.identifier } className={ gaugeClasses }></div>
+            <div id={ this.props.identifier } className={ gaugeClasses }  widget-type='InsightsGauge' widget-id={ this.props.identifier } ></div>
         );
     }
 }

--- a/src/Charts/Matrix/Matrix.js
+++ b/src/Charts/Matrix/Matrix.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import propTypes from 'prop-types';
 import { DataProps, ConfigProp, LabelsProp, ConfigDefaults, LabelsDefaults  } from './Props';
 import { select, event } from 'd3';
 import classnames from 'classnames';
@@ -82,7 +83,7 @@ class Matrix extends Component {
       labels
     } = this.props;
     return (
-      <div className="ins-matrix-chart">
+      <div identifier= { this.props.identifier } className="ins-matrix-chart" widget-type='InsightsMatrix' widget-id={ this.props.identifier }>
         <svg width={size} height={size} ref={ref => this.ref = ref}>
           <Axis size={gridSize} pad={pad} shift={shift}>
            {Object.values(data).map((oneSegment, key) => (
@@ -122,15 +123,25 @@ class Matrix extends Component {
   }
 }
 
+/**
+ * generate random ID if one is not supplied
+ */
+function generateId () {
+  let text = 'ins-gauge-' + new Date().getTime() + Math.random().toString(36).slice(2);
+  return text;
+}
+
 Matrix.propTypes = {
   data: DataProps.isRequired,
   config: ConfigProp,
-  labels: LabelsProp
+  labels: LabelsProp,
+  identifier: propTypes.string,
 };
 
 Matrix.defaultProps = {
   config: ConfigDefaults,
-  labels: LabelsDefaults
+  labels: LabelsDefaults,
+  identifier: generateId(),
 };
 
 export default Matrix;

--- a/src/Charts/Pie/Pie.js
+++ b/src/Charts/Pie/Pie.js
@@ -118,7 +118,7 @@ class Pie extends Component {
         }
 
         return (
-            <div className={ wrapperClasses }>
+            <div className={ wrapperClasses } widget-type='InsightsPie' widget-id={ this.props.identifier } >
                 <div className='ins-l-pie'>
                     <div id={ this.props.identifier } className={ pieClasses }></div>
                 </div>

--- a/src/PresentationalComponents/PageHeader/index.js
+++ b/src/PresentationalComponents/PageHeader/index.js
@@ -1,3 +1,3 @@
-export { default as PageHeaderTitle } from './PageHeaderTitle';
 export { default as PageHeader } from './PageHeader';
+export { default as PageHeaderTitle } from './PageHeaderTitle';
 import './styles.scss';

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ export * from './PresentationalComponents/Section';
 export * from './PresentationalComponents/SampleComponent';
 export * from './PresentationalComponents/Ansible';
 export * from './PresentationalComponents/Main';
-export * from './PresentationalComponents/PageHeader';
 export * from './PresentationalComponents/Pagination';
 export * from './PresentationalComponents/SimpleTableFilter';
 export * from './PresentationalComponents/Input';


### PR DESCRIPTION
QE wants attributes added to components, this is just for the charts. 

Also added an identifier to the matrix chart which is random if none is provided. This is so if there are multiple instances of Matrix, they can be identified.

PageHeader was being imported twice which threw errors, so this also removes the second import from the index.