### PR TITLE
updating dark page header class

### DIFF
--- a/src/PresentationalComponents/PageHeader/PageHeader.js
+++ b/src/PresentationalComponents/PageHeader/PageHeader.js
@@ -19,7 +19,7 @@ const PageHeader = ({ className, children, ...props }) => {
         <ThemeContext.Consumer>
             { theme => {
                 return (
-                    <section className={ `${ pageHeaderClasses } pf-m-${ theme }` } widget-type='InsightsPageHeader'>
+                    <section className={ `${ pageHeaderClasses } pf-m-${ theme }-200` } widget-type='InsightsPageHeader'>
                         <div className='pf-c-content'>
                             { children }
                         </div>


### PR DESCRIPTION
New patternfly styles need `pf-m-dark-200` on the pageHeader for the dark theme.