### PR TITLE
Adds aria label to breadcrumbs

### DIFF
--- a/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
+++ b/src/PresentationalComponents/Breadcrumbs/Breadcrumbs.js
@@ -15,7 +15,8 @@ const Breadcrumbs = ({ items, current, className, onNavigate, ...props }) => (
                 { items.map((oneLink, key) => (
                     <li key={ oneLink.navigate } data-key={ key }>
                         <a key={ oneLink.navigate }
-                            onClick={ event => onNavigate(event, oneLink.navigate, items.length - key) }>
+                            onClick={ event => onNavigate(event, oneLink.navigate, items.length - key) }
+                            aria-label={ oneLink.navigate }>
                             { upperCaseFirst(oneLink.title) }
                         </a>
                         <AngleRightIcon />


### PR DESCRIPTION
So we don't use pfr breadcrumbs or react-bootstrap breadcrumbs, so there need to set our own`aria-label`. 

(in case you were curious about what react-bst does https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Breadcrumb.js#L46)