### PR TITLE
Abstracts battery size to base class, adds zero styling

### DIFF
--- a/src/PresentationalComponents/Battery/battery.scss
+++ b/src/PresentationalComponents/Battery/battery.scss
@@ -5,39 +5,39 @@
   line-height: 1;
 }
 
+.ins-battery {
+  svg {
+    @include setBatteryFont;
+  }
+}
 
 // Setting the icons
 .ins-battery-1, .ins-battery-low, .ins-battery-info {
   svg {
-    @include setBatteryFont;
     path { fill: $ins-color--low; }
   }
 }
 
 .ins-battery-2, .ins-battery-medium, .ins-battery-warn {
   svg {
-    @include setBatteryFont;
     path { fill: $ins-color--medium; }
   }
 }
 
 .ins-battery-3, .ins-battery-high, .ins-battery-error{
   svg {
-    @include setBatteryFont;
     path { fill: $ins-color--high; }
   }
 }
 
 .ins-battery-4, .ins-battery-critical {
   svg {
-    @include setBatteryFont;
     path { fill: $ins-color--critical; }
   }
 }
 
-.ins-battery-null {
+.ins-battery-0, .ins-battery-null {
   svg {
-    @include setBatteryFont;
     path { fill: #d7d7d7; }
   }
 }


### PR DESCRIPTION
Now we won't ever blow up if there's a random string input, but also support 0 very nicely

### This is what we look like now
<img width="869" alt="screen shot 2018-10-22 at 9 35 58 am" src="https://user-images.githubusercontent.com/6640236/47297767-0fd9ec80-d5e4-11e8-9b03-0a9e7a03c13b.png">
