### PR TITLE
Fix SimpleTableFilter use of Dropdown.

### DIFF
--- a/src/PresentationalComponents/SimpleTableFilter/SimpleTableFilter.js
+++ b/src/PresentationalComponents/SimpleTableFilter/SimpleTableFilter.js
@@ -52,6 +52,9 @@ class SimpleFilter extends Component {
             ...props
         } = this.props;
         const { isOpen, selected } = this.state;
+        const dropdownItems = options.items.map(oneItem =>
+            <DropdownItem key={ oneItem.value } data-key={ oneItem.value }>{ oneItem.title }</DropdownItem>
+        );
         return (
             <div className={ `pf-c-input-group ${className}` } { ...props }>
                 {
@@ -64,11 +67,8 @@ class SimpleFilter extends Component {
                       { (selected && selected.title) || options.title || 'Dropdown' }
                   </DropdownToggle>
               }
-          >
-              { options.items.map(oneItem =>
-                  <DropdownItem key={ oneItem.value } data-key={ oneItem.value }>{ oneItem.title }</DropdownItem>
-              ) }
-          </Dropdown>
+              dropdownItems={ dropdownItems }
+          />
                 }
                 <Input placeholder={ placeholder } onChange={ this.onInputChange }/>
                 {


### PR DESCRIPTION
SimpleTableFilter: use the new way of passing DropdownItems to the Dropdown component.

http://patternfly-react.surge.sh/patternfly-4/components/dropdown

Fixes broken layout of the drop down list.