### PR TITLE
Added multiple notifications message key options

### DIFF
--- a/doc/components/notifications.md
+++ b/doc/components/notifications.md
@@ -240,3 +240,36 @@ notificationsMiddleware({
   errorDescriptionKey: 'body.description',
 })
 ```
+
+
+There might be also an situation when different APIs returns different error responses. You can configure multiple key paths to your error message.
+
+Lets say that our two endpoints have different error response structures:
+
+```javascript
+// Endpoint A
+{
+  errorTitle: 'Error',
+  errorDescription: 'Description'
+}
+// Endpoint B
+{
+  error: {
+    title: 'Error',
+    description: 'Description'
+  }
+}
+```
+
+We can tell the middleware that it should look for different keys in response:
+
+```javascript
+notificationsMiddleware({
+  errorTitleKey: ['errorTitle', 'error.title'],
+  errorDescriptionKey: ['errorDescription', 'error.description'],
+})
+```
+
+If you happen to have an error response that matches more paths, the first match will be chosen (order is equal to the order of items in array).
+
+

--- a/src/SmartComponents/Notifications/notifications.scss
+++ b/src/SmartComponents/Notifications/notifications.scss
@@ -2,7 +2,7 @@
   position: fixed;
   top: 0;
   right: 0;
-  z-index: 1000;
+  z-index: 2000;
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/SmartComponents/Notifications/notificationsMiddleware.js
+++ b/src/SmartComponents/Notifications/notificationsMiddleware.js
@@ -1,6 +1,28 @@
 
 import get from 'lodash/get';
+import has from 'lodash/has';
 import { addNotification } from '../../redux/actions/notifications';
+
+const prepareErrorMessage = (payload, errorTitleKey, errorDescriptionKey) => {
+    if (typeof payload === 'string') {
+        return {
+            title: 'Error',
+            description: payload
+        };
+    }
+
+    let titleKey = errorTitleKey;
+    if (Array.isArray(errorTitleKey)) {
+        titleKey = errorTitleKey.find(key => has(payload, key));
+    }
+
+    let descriptionKey = errorDescriptionKey;
+    if (Array.isArray(errorDescriptionKey)) {
+        descriptionKey = errorDescriptionKey.find(key => has(payload, key));
+    }
+
+    return { title: get(payload, titleKey) || 'Error', description: get(payload, descriptionKey) };
+};
 
 const shouldDispatchDefaultError = ({
     isRejected,
@@ -50,13 +72,10 @@ const createNotificationsMiddleware = (options = {}) => {
             noErrorOverride: meta && meta.noError,
             dispatchDefaultFailure: middlewareOptions.dispatchDefaultFailure
         })) {
-            const title = get(action.payload, middlewareOptions.errorTitleKey) || 'Error';
-            const description = typeof action.payload === 'string' ? action.payload : get(action.payload, middlewareOptions.errorDescriptionKey);
             dispatch(addNotification({
                 variant: 'danger',
-                title,
-                description,
-                dismissable: true
+                dismissable: true,
+                ...prepareErrorMessage(action.payload, middlewareOptions.errorTitleKey, middlewareOptions.errorDescriptionKey)
             }));
         }
 

--- a/src/SmartComponents/Notifications/notificationsMiddleware.test.js
+++ b/src/SmartComponents/Notifications/notificationsMiddleware.test.js
@@ -330,4 +330,32 @@ describe('Notifications middleware', () => {
       expect(initialProps.store.getActions()).toEqual(expectedActions)
     })
   });
+
+  it('should select second message key from configuration', () => {
+    middlewares = [promiseMiddleware(), notificationsMiddleware({
+      errorTitleKey: ['body.title', 'fooKey'],
+      errorDescriptionKey: ['body.description', 'barKey']
+    })];
+    mockStore = configureStore(middlewares);
+    const store = mockStore({});
+    const expectedActions = expect.arrayContaining([
+      expect.objectContaining({
+        type: ADD_NOTIFICATION,
+        payload: {
+          variant: 'danger',
+          dismissable: true,
+          title: 'Second title option',
+          description: 'Second description option'
+        }
+      }),
+      expect.any(Object)
+    ]);
+
+    return store.dispatch(requestMock(true, {
+      fooKey: 'Second title option',
+      barKey: 'Second description option'
+    })).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions)
+    })
+  });
 });


### PR DESCRIPTION
Added option to specify multiple formats for error responses for automatic notifications.

Also i had to increase z-index of notification container once again. I will create probably a section in docs that will document z-index values in insights applications. So far i have these values:

- main-content: 100
- side-bar: 200
- page-header: 300
- account button in top right corner - the border had 1000 now it seems to be 300 also.