### PR TITLE
Do not dispatch new action from router params if on same page

### DIFF
--- a/src/SmartComponents/Inventory/Filter/Filter.js
+++ b/src/SmartComponents/Inventory/Filter/Filter.js
@@ -9,7 +9,6 @@ import { filterSelect } from '../../../redux/actions/inventory';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import { InventoryContext } from '../Inventory';
 import FilterItem from './FilterItem';
-import debounce from 'lodash/debounce';
 
 function generateFilters(filters = [], activeFilters) {
     const calculateFilter = (filter, { value }) => ({
@@ -27,7 +26,7 @@ function generateFilters(filters = [], activeFilters) {
             filter,
             isDisabled: true
         },
-        ...items.flatMap(({ items: subItems, ...subFilter }) => ([
+        ...items ? items.flatMap(({ items: subItems, ...subFilter }) => ([
             {
                 filter: {
                     ...calculateFilter(subFilter, filter),
@@ -38,7 +37,7 @@ function generateFilters(filters = [], activeFilters) {
                 filter: calculateFilter(itemFilter, filter),
                 pad: 1
             })) : []
-        ]))
+        ])) : []
     ]));
 }
 

--- a/src/Utilities/RouterParams.js
+++ b/src/Utilities/RouterParams.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withRouter, matchPath } from 'react-router-dom';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 
 export default function(Component) {
   class RouterParams extends React.Component {
@@ -15,21 +16,23 @@ export default function(Component) {
     }
 
     componentDidUpdate () {
-      const { match: {params, path, url}, onPathChange, location } = this.props;
-      if (matchPath(location.pathname, {path: url, exact: true})) {
-        onPathChange && onPathChange({
-          params,
-          path
-        });
-      }
+        const { match: { params, path, url }, onPathChange, location, routerData } = this.props;
+        if (!isEqual(params, routerData.params) || path !== routerData.path) {
+            if (matchPath(location.pathname, { path: url, exact: true })) {
+                onPathChange && onPathChange({
+                    params,
+                    path
+                });
+            }
+        }
     }
 
     render () {
         const { onPathChange, ...props } = this.props;
         return <Component { ...props }/>;
     }
-  };
-  return withRouter(connect(() => ({}), (dispatch) => (
+};
+return withRouter(connect(({ routerData }) => ({ routerData }), (dispatch) => (
     {
       onPathChange: (data) => dispatch({
         type: '@@INSIGHTS-CORE/NAVIGATION',

--- a/src/api/inventory.js
+++ b/src/api/inventory.js
@@ -1,57 +1,5 @@
 export const INVENTORY_API_BASE = '/r/insights/platform/inventory/api/v1/hosts';
 
-/* eslint camelcase: off */
-function buildMock(i) {
-    return {
-        id: `${i}`,
-        canonical_facts: {
-            machine_id: `${i}c1497de-0ec7-43bb-a8a6-35cabd59e0bf`
-        },
-        account: '000001',
-        facts: [
-            {
-                facts: {
-                    hostname: `server0${i}.redhat.com`,
-                    machine_id: `${i}c1497de-0ec7-43bb-a8a6-35cabd59e0bf`,
-                    release: 'Red Hat Enterprise Linux Server release 7.5 (Maipo)',
-                    rhel_version: '7.5',
-                    host_system_id: '6c1497de-0ec7-43bb-a8a6-35cabd59e0bf',
-                    bios_information: {
-                        vendor: 'SeaBIOS',
-                        version: '1.10.2-3.el7_4.1',
-                        release_date: '04/01/2014',
-                        bios_revision: '0.0'
-                    },
-                    system_information: {
-                        family: 'Red Hat Enterprise Linux',
-                        manufacturer: 'Red Hat',
-                        product_name: 'RHEV Hypervisor',
-                        virtual_machine: true
-                    },
-                    listening_processes: [],
-                    timezone_information: {
-                        timezone: 'EDT',
-                        utcoffset: '-0400'
-                    }
-                },
-                namespace: 'inventory'
-            }
-        ],
-        display_name: 'Red Hat Enterprise Linux 8'
-    };
-}
-
-function mockData(id) {
-    const mocked = Array.from({ length: 5 }).map((_v, i) => buildMock(i));
-    return id !== undefined ? {
-        count: 1,
-        results: [ mocked[id] ]
-    } : {
-        count: 5,
-        results: mocked
-    };
-}
-
 const mapData = ({ results = [], ...data }) => ({
     ...data,
     results: results.map(({ facts = {}, ...oneResult }) => ({
@@ -100,11 +48,6 @@ export function getEntities(items, { base = INVENTORY_API_BASE, ...rest }) {
         () => fetch(`${base}${items.length !== 0 ? '/' + items : ''}${query}`).then(r => {
             if (r.ok) {
                 return r.json().then(mapData);
-            }
-
-            // TODO: remove me
-            if (r.status === 404) {
-                return mapData(mockData(items));
             }
 
             throw new Error(`Unexpected response code ${r.status}`);

--- a/src/api/inventory.js
+++ b/src/api/inventory.js
@@ -1,5 +1,6 @@
 export const INVENTORY_API_BASE = '/r/insights/platform/inventory/api/v1/hosts';
 
+/* eslint camelcase: off */
 const mapData = ({ results = [], ...data }) => ({
     ...data,
     results: results.map(({ facts = {}, ...oneResult }) => ({

--- a/src/api/inventory.js
+++ b/src/api/inventory.js
@@ -96,16 +96,18 @@ function buildQuery({ per_page, page, filters }) {
 export function getEntities(items, { base = INVENTORY_API_BASE, ...rest }) {
     let query = buildQuery(rest);
 
-    return fetch(`${base}${items.length !== 0 ? '/' + items : ''}${query}`).then(r => {
-        if (r.ok) {
-            return r.json().then(mapData);
-        }
+    return insights.chrome.auth.getUser().then(
+        () => fetch(`${base}${items.length !== 0 ? '/' + items : ''}${query}`).then(r => {
+            if (r.ok) {
+                return r.json().then(mapData);
+            }
 
-        // TODO: remove me
-        if (r.status === 404) {
-            return mapData(mockData(items));
-        }
+            // TODO: remove me
+            if (r.status === 404) {
+                return mapData(mockData(items));
+            }
 
-        throw new Error(`Unexpected response code ${r.status}`);
-    });
+            throw new Error(`Unexpected response code ${r.status}`);
+        })
+    );
 }


### PR DESCRIPTION
One nasty bug appears in advisor that the page gets into infinite loop of refreshes because multiple components change router params to same, but they treat it as different. This fixes such issue by comparing params and path and if either params or path is different do path update, if not do not fire such update.