### PR TITLE
Ensures we only return pagination row once its not of type undefined

### DIFF
--- a/src/PresentationalComponents/Pagination/Pagination.js
+++ b/src/PresentationalComponents/Pagination/Pagination.js
@@ -62,7 +62,7 @@ class Pagination extends Component {
 
         return (
             <div className="special-patternfly" widget-type='InsightsPagination'>
-                { PaginationRow && <PaginationRow
+                { typeof PaginationRow !== 'undefined' && <PaginationRow
                     { ...this.props }
                     pageInputValue={ this.props.page || 1 }
                     viewType={ this.props.viewType || 'table' }


### PR DESCRIPTION
Every no and again, loading inventory table for the first time would throw

### this error :scream:
<img width="1075" alt="screen shot 2019-01-16 at 7 55 37 am" src="https://user-images.githubusercontent.com/6640236/51250675-22568e80-1965-11e9-844f-bfebb15128ea.png">

Super not cool. It crashes the app.  This pr fixes that