### PR TITLE
Add option to hide checkboxes in EntityTable + don't override cols by default

### DIFF
--- a/src/SmartComponents/Inventory/EntityTable.js
+++ b/src/SmartComponents/Inventory/EntityTable.js
@@ -127,7 +127,7 @@ class EntityTable extends React.Component {
     }
 
     render() {
-        const { columns, showHealth, loaded, sortBy, expandable, onExpandClick } = this.props;
+        const { columns, showHealth, loaded, sortBy, expandable, onExpandClick, hasCheckbox } = this.props;
         return <Table
             className="pf-m-compact ins-entity-table"
             expandable={ expandable }
@@ -152,7 +152,7 @@ class EntityTable extends React.Component {
             } }
             onSort={ this.onSort }
             onItemSelect={ this.onItemSelect }
-            hasCheckbox={ loaded }
+            hasCheckbox={ loaded && hasCheckbox }
             rows={
                 loaded ?
                     this.createRows() :
@@ -172,6 +172,7 @@ EntityTable.propTypes = {
     expandable: PropTypes.bool,
     onExpandClick: PropTypes.func,
     setSort: PropTypes.func,
+    hasCheckbox: PropTypes.bool,
     rows: PropTypes.arrayOf(PropTypes.any),
     columns: PropTypes.arrayOf(PropTypes.shape({
         key: PropTypes.string,
@@ -193,6 +194,7 @@ EntityTable.defaultProps = {
     loaded: false,
     showHealth: false,
     expandable: false,
+    hasCheckbox: true,
     columns: [],
     rows: [],
     onExpandClick: () => undefined,

--- a/src/redux/reducers/inventory/entities.js
+++ b/src/redux/reducers/inventory/entities.js
@@ -19,7 +19,7 @@ const defaultColumns = [
 function entitiesPending(state) {
     return {
         ...state,
-        columns: mergeArraysByKey([ state.columns, defaultColumns ], 'key'),
+        columns: mergeArraysByKey([ defaultColumns, state.columns ], 'key'),
         rows: [],
         activeFilters: [],
         loaded: false


### PR DESCRIPTION
* EntityTable has an option to hide checkboxes for rows, by default they're shown as before.
* When specifying custom cols for table, don't override them with default cols, process it vice versa instead. 