### PR TITLE
Use custom class for insights tables

### DIFF
--- a/src/PresentationalComponents/Table/Table.js
+++ b/src/PresentationalComponents/Table/Table.js
@@ -44,6 +44,7 @@ const Table = ({
             className={
                 classnames(
                     'pf-c-table',
+                    'ins-c-table',
                     props.variant !== TableVariant.large && 'pf-m-compact',
                     className
                 )

--- a/src/PresentationalComponents/Table/table.scss
+++ b/src/PresentationalComponents/Table/table.scss
@@ -2,7 +2,7 @@
 @import '~@patternfly/patternfly-next/sass-utilities/scss-variables';
 @import './Table/styles.scss';
 
-.pf-c-table {
+.pf-c-table.ins-c-table {
   border: 1px solid #ccc;
   background-color: var(--pf-c-table--BackgroundColor);
   box-shadow: var(--pf-global--BoxShadow);
@@ -66,7 +66,7 @@
 
 
 @media screen and (max-width: 992px) {
-  .pf-c-table {
+  .pf-c-table.ins-c-table {
     &, tr {
       border: 1px solid #ccc;
     }


### PR DESCRIPTION
Since patternfly has new tables we should add custom class to our styling so we don't override patternfly's.