### PR TITLE
fixes advisorapp fetch, awaits getUser() then calls fetch

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -27,9 +27,8 @@ class InventoryRuleList extends Component {
     async fetchEntityRules() {
         const { entity } = this.props;
         try {
-            const data = await insights.chrome.auth.getUser(
-                () => fetch(`${SYSTEM_FETCH_URL}${entity.id}/reports`).then(data => data.json()).catch(error => {throw error;})
-            );
+            await insights.chrome.auth.getUser();
+            const data = await fetch(`${SYSTEM_FETCH_URL}${entity.id}/reports`).then(data => data.json()).catch(error => {throw error;});
             this.setState({
                 inventoryReport: data,
                 inventoryReportFetchStatus: 'fulfilled'


### PR DESCRIPTION
OK ok for whatever reason I wasnt seeing this when reviewing https://github.com/RedHatInsights/insights-frontend-components/pull/253 but ends up `getUser` takes no arguments, but we can await for it, THEN fetch, this solves the original issue...