### PR TITLE
Include credentials on inventory entity request

### DIFF
--- a/src/api/inventory.js
+++ b/src/api/inventory.js
@@ -55,7 +55,7 @@ export function getEntities(items, { base = INVENTORY_API_BASE, ...rest }) {
     let query = buildQuery(rest);
 
     return insights.chrome.auth.getUser().then(
-        () => fetch(`${base}${items.length !== 0 ? '/' + items : ''}${query}`).then(r => {
+        () => fetch(`${base}${items.length !== 0 ? '/' + items : ''}${query}`, { credentials: 'include' }).then(r => {
             if (r.ok) {
                 return r.json().then(({ results = [], ...data }) => ({
                     ...data,


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
```By default, fetch won't send or receive any cookies from the server, resulting in unauthenticated requests if the site relies on maintaining a user session (to send cookies, the credentials init option must be set).```

`{ credentials: 'include' }` makes the request work for me when I do the fetch in the console.