### PR TITLE
Hide filters if consumer passes items

### DIFF
--- a/src/SmartComponents/Inventory/Filter/Filter.js
+++ b/src/SmartComponents/Inventory/Filter/Filter.js
@@ -108,43 +108,49 @@ class ContextFilter extends Component {
     }
 
     render() {
-        const { columns, total, children } = this.props;
+        const { columns, total, children, items } = this.props;
         const { filterByString, isOpen, filters } = this.state;
         const filteredColumns = columns && columns.filter(column => !column.isTime);
         const placeholder = filterByString || (filteredColumns && filteredColumns.length > 0 && filteredColumns[0].title);
         return (
             <Grid guttter="sm" className="ins-inventory-filters">
-                <GridItem span={ 4 } className="ins-inventory-text-filter">
-                    <SimpleTableFilter
-                        options={
-                            filteredColumns && filteredColumns.length > 1 ? {
-                                title: columns[0].title,
-                                items: columns.map(column => ({
-                                    ...column,
-                                    value: column.key
-                                }))
-                            } : undefined
-                        }
-                        onOptionSelect={ this.onFilterByString }
-                        onFilterChange={ this.filterEntities }
-                        placeholder={ `Find system by ${placeholder}` }
-                        buttonTitle=""
-                    />
-                </GridItem>
-                <GridItem span={ 1 } className="ins-inventory-filter">
-                    { filters && filters.length > 0 && <Dropdown
-                        isOpen={ isOpen }
-                        dropdownItems={ filters.map((item, key) => (
-                            <FilterItem
-                                { ...item }
-                                key={ key }
-                                data-key={ key }
-                                onClick={ (event) => this.onFilterClick(event, item.filter, key) }
-                            />
-                        )) }
-                        toggle={ <DropdownToggle onToggle={ this.onToggle }>Filter</DropdownToggle> }
-                    /> }
-                </GridItem>
+                {
+                    (!items || items.length === 0) &&
+                    <GridItem span={ 4 } className="ins-inventory-text-filter">
+                        <SimpleTableFilter
+                            options={
+                                filteredColumns && filteredColumns.length > 1 ? {
+                                    title: columns[0].title,
+                                    items: columns.map(column => ({
+                                        ...column,
+                                        value: column.key
+                                    }))
+                                } : undefined
+                            }
+                            onOptionSelect={ this.onFilterByString }
+                            onFilterChange={ this.filterEntities }
+                            placeholder={ `Find system by ${placeholder}` }
+                            buttonTitle=""
+                        />
+                    </GridItem>
+                }
+                {
+                    filters && filters.length > 0 &&
+                    <GridItem span={ 1 } className="ins-inventory-filter">
+                        <Dropdown
+                            isOpen={ isOpen }
+                            dropdownItems={ filters.map((item, key) => (
+                                <FilterItem
+                                    { ...item }
+                                    key={ key }
+                                    data-key={ key }
+                                    onClick={ (event) => this.onFilterClick(event, item.filter, key) }
+                                />
+                            )) }
+                            toggle={ <DropdownToggle onToggle={ this.onToggle }>Filter</DropdownToggle> }
+                        />
+                    </GridItem>
+                }
                 <GridItem span={ 6 }>
                     { children }
                 </GridItem>
@@ -189,7 +195,8 @@ Filter.propTypes = {
     activeFilters: PropTypes.arrayOf(PropTypes.shape({
         title: PropTypes.string,
         value: PropTypes.string
-    }))
+    })),
+    items: PropTypes.array
 };
 Filter.defaultProps = {
     filters: [],

--- a/src/SmartComponents/Inventory/Filter/Filter.js
+++ b/src/SmartComponents/Inventory/Filter/Filter.js
@@ -151,7 +151,7 @@ class ContextFilter extends Component {
                         />
                     </GridItem>
                 }
-                <GridItem span={ 6 }>
+                <GridItem span={ hasItems ? 10 : 6 }>
                     { children }
                 </GridItem>
                 <GridItem span={ 1 } className="ins-inventory-total pf-u-display-flex pf-u-align-items-center">

--- a/src/SmartComponents/Inventory/Filter/Filter.js
+++ b/src/SmartComponents/Inventory/Filter/Filter.js
@@ -108,14 +108,14 @@ class ContextFilter extends Component {
     }
 
     render() {
-        const { columns, total, children, items } = this.props;
+        const { columns, total, children, hasItems } = this.props;
         const { filterByString, isOpen, filters } = this.state;
         const filteredColumns = columns && columns.filter(column => !column.isTime);
         const placeholder = filterByString || (filteredColumns && filteredColumns.length > 0 && filteredColumns[0].title);
         return (
             <Grid guttter="sm" className="ins-inventory-filters">
                 {
-                    (!items || items.length === 0) &&
+                    !hasItems &&
                     <GridItem span={ 4 } className="ins-inventory-text-filter">
                         <SimpleTableFilter
                             options={
@@ -196,7 +196,7 @@ Filter.propTypes = {
         title: PropTypes.string,
         value: PropTypes.string
     })),
-    items: PropTypes.array
+    hasItems: PropTypes.bool
 };
 Filter.defaultProps = {
     filters: [],

--- a/src/SmartComponents/Inventory/Inventory.js
+++ b/src/SmartComponents/Inventory/Inventory.js
@@ -41,7 +41,12 @@ class InventoryTable extends Component {
             } }>
                 <Card>
                     <CardHeader>
-                        <Filter { ...props } items={ items } filters={ filters } pathPrefix={ pathPrefix } apiBase={ apiBase } />
+                        <Filter { ...props }
+                            hasItems={ items && items.length !== 0 }
+                            filters={ filters }
+                            pathPrefix={ pathPrefix }
+                            apiBase={ apiBase }
+                        />
                     </CardHeader>
                     <CardBody>
                         <InventoryList

--- a/src/SmartComponents/Inventory/Inventory.js
+++ b/src/SmartComponents/Inventory/Inventory.js
@@ -41,7 +41,7 @@ class InventoryTable extends Component {
             } }>
                 <Card>
                     <CardHeader>
-                        <Filter { ...props } filters={ filters } pathPrefix={ pathPrefix } apiBase={ apiBase } />
+                        <Filter { ...props } items={ items } filters={ filters } pathPrefix={ pathPrefix } apiBase={ apiBase } />
                     </CardHeader>
                     <CardBody>
                         <InventoryList

--- a/src/SmartComponents/Inventory/InventoryList.js
+++ b/src/SmartComponents/Inventory/InventoryList.js
@@ -103,14 +103,16 @@ function mapDispatchToProps(dispatch) {
                 console.error('Wrong shape of items, array with strings or objects with ID property required!');
             }
 
-            const itemIds = items.reduce((acc, curr) => (
+            const limitedItems = items.slice(config.page - 1 * config.per_page, config.per_page);
+
+            const itemIds = limitedItems.reduce((acc, curr) => (
                 [
                     ...acc,
                     curr && typeof curr === 'string' ? curr : curr.id
                 ]
             ), []).filter(Boolean);
             dispatch(loadEntities(itemIds, config));
-            dispatch(showEntities(items.map(oneItem => (
+            dispatch(showEntities(limitedItems.map(oneItem => (
                 { ...typeof oneItem === 'string' ? { id: oneItem } : oneItem }
             ))));
         }


### PR DESCRIPTION
This is follow up from discussion we had yesterday about hiding filters if consumers (applications) will pass any items (eg try to limit the search).

No change in API, everytime you pass array of items inventory will limit the amount based on current page and per_page option.

Without this change if any aplication asks for more than 100 IDs API will throw error that request is too large and fails.

If we apply this change every application that passes any amount of items will loose the ability to filter inventory table (it was already )