### PR TITLE
updating styling for expandable rules card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6816,7 +6816,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8390,7 +8390,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8588,7 +8588,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {

--- a/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
+++ b/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import classNames from 'classnames';
 import { BullseyeIcon, ChevronDownIcon, ChevronRightIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
-import { Card, CardBody, CardHeader, Grid, GridItem, List, ListItem, Split, SplitItem } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Stack, StackItem, List, ListItem, Split, SplitItem } from '@patternfly/react-core';
 import doT from 'dot';
 import sanitizeHtml from 'sanitize-html';
 import marked from 'marked';
@@ -65,9 +65,8 @@ class ExpandableRulesCard extends React.Component {
         const rule = report.rule || report;
         const { expanded, kbaDetail } = this.state;
         let rulesCardClasses = classNames(
-            'ins-c-rules-card',
-            'pf-t-light',
-            'pf-m-opaque-100'
+            'ins-c-inventory-advisor__card',
+            'ins-c-rules-card'
         );
         return (
             <Card className={ rulesCardClasses } widget-type='InsightsRulesCard'>
@@ -90,27 +89,39 @@ class ExpandableRulesCard extends React.Component {
                     </Section>
                 </CardHeader>
                 { expanded && <CardBody>
-                    <Grid gutter='md' sm={ 12 }>
-                        <GridItem>
-                            <Card className='pf-t-light  pf-m-opaque-100'>
-                                <CardHeader> <ThumbsUpIcon/> Detected Issues</CardHeader>
+                    <Stack gutter='md'>
+                        <StackItem>
+                            <Card className='ins-m-card__flat'>
+                                <CardHeader>
+                                    <ThumbsUpIcon/>
+                                    <strong>Detected Issues</strong>
+                                </CardHeader>
                                 <CardBody>
                                     { rule.reason && this.templateProcessor(rule.reason, report.details) }
                                 </CardBody>
                             </Card>
-                        </GridItem>
-                        <GridItem>
-                            <Card className='pf-t-light  pf-m-opaque-100'>
-                                <CardHeader> <BullseyeIcon/> Steps to resolve</CardHeader>
+                        </StackItem>
+                        <StackItem>
+                            <Card className='ins-m-card__flat'>
+                                <CardHeader>
+                                    <BullseyeIcon/>
+                                    <strong>Steps to resolve</strong>
+                                </CardHeader>
                                 <CardBody>
                                     { report.resolution && this.templateProcessor(report.resolution.resolution, report.details) }
                                 </CardBody>
                             </Card>
-                        </GridItem>
-                        { kbaDetail && kbaDetail.view_uri && <GridItem>
-                            <LightbulbIcon/><strong>Related Knowledgebase articles: </strong>
-                            <a href={ `${kbaDetail.view_uri}` } rel="noopener">{ kbaDetail.publishedTitle }</a>
-                        </GridItem> }
+                        </StackItem>
+                        { kbaDetail && kbaDetail.view_uri && <StackItem>
+                            <Card className='ins-m-card__flat'>
+                                <CardHeader>
+                                    <LightbulbIcon/><strong>Related Knowledgebase articles: </strong>
+                                </CardHeader>
+                                <CardBody>
+                                    <a href={ `${kbaDetail.view_uri}` } rel="noopener">{ kbaDetail.publishedTitle }</a>
+                                </CardBody>
+                            </Card>
+                        </StackItem> }
                         <div>
                             { rule.more_info && this.templateProcessor(rule.more_info) }
                             <List>
@@ -128,7 +139,7 @@ class ExpandableRulesCard extends React.Component {
                                 </ListItem>
                             </List>
                         </div>
-                    </Grid>
+                    </Stack>
                 </CardBody> }
             </Card>
         );

--- a/src/SmartComponents/Inventory/applications/advisor/advisor.scss
+++ b/src/SmartComponents/Inventory/applications/advisor/advisor.scss
@@ -29,22 +29,47 @@
     &:hover { text-decoration: none; }
 }
 
-pre {
-    display: block;
-    padding: 9.5px;
-    margin: 0 0 10px;
-    color: #333;
-    word-break: break-all;
-    word-wrap: break-word;
-    background-color: #f5f5f5;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-}
+.ins-c-inventory-advisor__card {
 
-pre code {
-    padding: 0;
-    color: inherit;
-    white-space: pre-wrap;
-    background-color: transparent;
-    border-radius: 0;
+    .ins-m-card__flat {
+        box-shadow: none;
+        border: 1px solid #dcdcdc;
+        border-radius: 5px;
+    }
+
+    .pf-c-card__body svg { @include rem('margin-right', 5px); }
+
+    pre {
+        display: block;
+        @include rem('padding', 9.5px);
+        @include rem('margin-top', 5px);
+        @include rem('margin-bottom', 10px);
+        color: #333;
+        word-break: break-all;
+        word-wrap: break-word;
+        background-color: #f5f5f5;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        code { white-space: normal; }
+    }
+
+    ol {
+        @include rem('margin-top', 10px);
+        @include rem('margin-left', 15px);
+    }
+
+    p + pre, ul + pre { @include rem('margin-bottom', 20px); }
+
+    .pf-c-list { @include rem('margin', 5px 0); }
+
+    table {
+        width: 100%;
+        @include rem('margin-top', 15px);
+        tr { border-bottom: 1px solid #ededed; }
+        th, td { @include rem('padding', 16px); }
+
+        // Inline style overwrite
+        td { background: white !important; }
+        th { text-align: left !important; }
+    }
 }


### PR DESCRIPTION
[RHIADVISOR-407](https://projects.engineering.redhat.com/browse/RHIADVISOR-407)

cc: @kensible

Before:

![image](https://user-images.githubusercontent.com/12520842/52285342-26f2df00-2934-11e9-974b-56b2090cf397.png)

After:
![screen shot 2019-02-05 at 10 44 21 am](https://user-images.githubusercontent.com/12520842/52285371-32460a80-2934-11e9-9218-021b3eac358c.png)
![screen shot 2019-02-05 at 10 44 30 am](https://user-images.githubusercontent.com/12520842/52285370-32460a80-2934-11e9-9a27-80be90d2fdb8.png)


This also fixes 
- items inside of `code` tags wouldn't wrap and extend past the edges of the page.
- Removing unnecessary Grid components when Stacks should be used
- redundant styling