### PR TITLE
Updates to SystemDetails for Compliance

### DIFF
--- a/src/SmartComponents/Inventory/applications/compliance/SystemPolicyCard.js
+++ b/src/SmartComponents/Inventory/applications/compliance/SystemPolicyCard.js
@@ -1,59 +1,56 @@
 import React from 'react';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import PropTypes from 'prop-types';
 import {
     Card,
-    CardHeader,
     CardBody,
     CardFooter,
     Text,
     TextContent,
     TextVariants
 } from '@patternfly/react-core';
-
-/* eslint camelcase: off */
+import PropTypes from 'prop-types';
 
 class SystemPolicyCard extends React.Component {
-    complianceIcon = (compliant) => {
-        if (compliant) {
-            return <div style={ { fontSize: 'large', color: '#92d400' } } id='policy_compliant'>
+    complianceIcon = () => {
+        const { policy: { compliant }} = this.props;
+
+        return compliant ?
+            <div className='ins-c-policy-card ins-m-compliant'>
                 <CheckCircleIcon /> Compliant
-            </div>;
-        } else {
-            return <div style={ { fontSize: 'large', color: '#a30000' } } id='policy_compliant'>
+            </div> :
+            <div className='ins-c-policy-card ins-m-noncompliant'>
                 <ExclamationCircleIcon/> Noncompliant
             </div>;
-        }
     }
 
     render() {
-        const { policy } = this.props;
+        /* eslint-disable camelcase */
+        const { policy: { name, compliant, ref_id, last_scanned, rules_passed, rules_failed }} = this.props;
         return (
             <Card>
                 <CardBody>
                     <TextContent>
-                        <Text style={ { marginBottom: '0px' } } component={ TextVariants.small }>External Policy</Text>
-                        <Text style={ { marginBottom: '0px' } } component={ TextVariants.medium }>{ policy.name }</Text>
+                        <Text style={ { marginBottom: '0' } } component={ TextVariants.small }>External Policy</Text>
+                        <Text style={ { marginTop: '0' } } component={ TextVariants.h4 }>{ name }</Text>
                     </TextContent>
-                    <TextContent>
-                        { this.complianceIcon(policy.compliant) }
-                        <Text component={ TextVariants.small }>
-                            { policy.rules_passed } of { policy.rules_passed + policy.rules_failed } passed
-                        </Text>
-                        <Text component={ TextVariants.medium }>
-                            Profile <br/>
-                            { policy.ref_id }
-                        </Text>
-                    </TextContent>
+                    { this.complianceIcon(compliant) }
+                    <Text component={ TextVariants.small }>
+                        { rules_passed } of { rules_passed + rules_failed } rules passed
+                    </Text>
+                    <Text component={ TextVariants.medium }>
+                        Profile <br/>
+                        { ref_id }
+                    </Text>
                 </CardBody>
                 <CardFooter>
                     <TextContent>
                         <Text component={ TextVariants.small }>
-                          Last scanned: { policy.last_scanned }
+                          Last scanned: { last_scanned }
                         </Text>
                     </TextContent>
                 </CardFooter>
             </Card>
+            /* eslint-disable camelcase */
         );
     };
 };
@@ -64,6 +61,7 @@ SystemPolicyCard.propTypes = {
         rules_failed: PropTypes.number,
         last_scanned: PropTypes.string,
         ref_id: PropTypes.string,
+        name: PropTypes.string,
         compliant: PropTypes.bool
     })
 };

--- a/src/SmartComponents/Inventory/applications/compliance/SystemPolicyCards.js
+++ b/src/SmartComponents/Inventory/applications/compliance/SystemPolicyCards.js
@@ -6,16 +6,22 @@ import propTypes from 'prop-types';
 import { Instagram } from 'react-content-loader';
 
 class SystemPolicyCards extends React.Component {
+    systemPolicyCards() {
+        return this.props.policies.map(
+            (policy, i) =>
+                <GridItem sm={ 12 } md={ 12 } lg={ 6 } xl={ 4 } key={ i }>
+                    <SystemPolicyCard policy={ policy } />
+                </GridItem>
+        );
+    }
+
     render() {
-        const { policies, loading } = this.props;
+        const { loading } = this.props;
+
         return (
-            <div id="system_policy_cards">
+            <React.Fragment>
                 <Grid gutter='md'>
-                    { policies.map((policy, i) => (
-                        <GridItem span={ 4 } key={ i }>
-                            <SystemPolicyCard policy={ policy } />
-                        </GridItem>
-                    )) }
+                    { this.systemPolicyCards() }
                     { loading && [ ...Array(3) ].map((_item, i) => (
                         <GridItem span={ 4 } key={ i }>
                             <Card>
@@ -26,7 +32,7 @@ class SystemPolicyCards extends React.Component {
                         </GridItem>
                     )) }
                 </Grid>
-            </div>
+            </React.Fragment>
         );
     }
 }

--- a/src/SmartComponents/Inventory/applications/compliance/compliance.scss
+++ b/src/SmartComponents/Inventory/applications/compliance/compliance.scss
@@ -2,7 +2,22 @@
     text-align: center;
 }
 
-#remediation-button > button {
-    padding-left: 0.625rem;
-    padding-right: 0.625rem;
+.ins-c-policy-card {
+    font-size: var(--pf-global--FontSize--lg);
+}
+
+.ins-c-policy-card.ins-m-compliant {
+    color: var(--pf-global--success-color--100);
+}
+
+.ins-c-policy-card.ins-m-noncompliant {
+    color: var(--pf-global--danger-color--100);
+}
+
+.ins-u-passed {
+    color: var(--pf-global--success-color--100);
+}
+
+.ins-u-failed {
+    color: var(--pf-global--danger-color--100);
 }


### PR DESCRIPTION
This contains the required changes so that:

1. The tab works again
2. I can drop the system details page from compliance-frontend and start using the component from here directly.

![screenshot from 2019-02-14 19-26-01](https://user-images.githubusercontent.com/598891/52808610-96807100-308e-11e9-8429-1e5529797c8e.png)
![screenshot from 2019-02-14 19-25-47](https://user-images.githubusercontent.com/598891/52808611-97190780-308e-11e9-9a95-d840bb58ade3.png)
![screenshot from 2019-02-14 19-25-37](https://user-images.githubusercontent.com/598891/52808613-97190780-308e-11e9-8f76-b84ceee48197.png)
![screenshot from 2019-02-13 21-37-46](https://user-images.githubusercontent.com/598891/52808614-97190780-308e-11e9-9059-6c071a0e7fed.png)
