### PR TITLE
fixing content sizing in wizard <?.?.x>

### DIFF
--- a/src/PresentationalComponents/Wizard/wizard.scss
+++ b/src/PresentationalComponents/Wizard/wizard.scss
@@ -1,4 +1,7 @@
 .pf-c-modal-box.ins-c-wizard {
     min-height: 75vh;
     min-width: 75vw;
+    
+    // Style override, this max-height is actually set above by the overall wizard height
+    .pf-c-modal-box__body { max-height: none; }
 }


### PR DESCRIPTION
Updated PF set a max height of the content in the modal.

The modal component size is based on the content, we want it a consistent size and always allow the content to occupy the rest of the space.