### PR TITLE
Ensure we use the output of getResolutionsBatch in Compliance

### DIFF
--- a/src/SmartComponents/Inventory/applications/compliance/SystemRulesTable.js
+++ b/src/SmartComponents/Inventory/applications/compliance/SystemRulesTable.js
@@ -112,21 +112,14 @@ class SystemRulesTable extends React.Component {
         return window.insights.chrome.auth.getUser()
         .then(() => {
             return remediationsApi.getResolutionsBatch(ruleIds)
-            .then((response) => {
-                if (!response.ok) {
-                    // If remediations doesn't respond, inject no fix available
-                    return {};
-                }
-
-                return response.json();
-            });
-        }).then(response => newRows.map(({ cells, ...row }) => ({
-            ...row,
-            cells: [
-                ...cells,
-                ...this.isParent(row, cells) ? [ this.remediationAvailable(response[`compliance:${refIds[cells[0]]}`]) ] : []
-            ]
-        })));
+            .then(response => newRows.map(({ cells, ...row }) => ({
+                ...row,
+                cells: [
+                    ...cells,
+                    ...this.isParent(row, cells) ? [ this.remediationAvailable(response[`compliance:${refIds[cells[0]]}`]) ] : []
+                ]
+            })));
+        });
     }
 
     selectAll = (rows, selected) => {


### PR DESCRIPTION
Before this change, we were checking for 'response.ok'. That would have
been OK if we handled the HTTP request ourselves. But since that's
handled by the getResolutionsBatch method, the value returned from that
method is the actual result directly, without any info about the request.

Therefore, 'request.ok' is undefined and makes it appear as if there
were no remediations available, as we are passed {} as the list of
remediations available. To fix this, we simply need to use the method as
intended, and parse the output without checking the status of the request.