### PR TITLE
Use lodash flatMap everywhere

### DIFF
--- a/src/SmartComponents/Inventory/applications/compliance/SystemRulesTable.js
+++ b/src/SmartComponents/Inventory/applications/compliance/SystemRulesTable.js
@@ -101,7 +101,7 @@ class SystemRulesTable extends React.Component {
 
         const firstIndex = (page - 1) * itemsPerPage * 2;
         const lastIndex = page * itemsPerPage * 2;
-        const newRows = rows.slice(firstIndex, lastIndex).flatMap(({ parent, ...row }) => ({
+        const newRows = flatMap(rows.slice(firstIndex, lastIndex), ({ parent, ...row }) => ({
             ...row,
             ...((parent || parent === 0) ? parent > itemsPerPage ? { parent: parent % (itemsPerPage * 2) } : { parent } : {})
         }));


### PR DESCRIPTION
@dLobatog  We missed one `flatMap` [here](https://github.com/RedHatInsights/insights-frontend-components/pull/300/files#diff-5230d89f4eac167412db557ad0e2fd13R104).