### PR TITLE
Fixes #RHICOMPL-87: divide total rule result rows by 2

### DIFF
--- a/src/SmartComponents/Inventory/applications/compliance/SystemRulesTable.js
+++ b/src/SmartComponents/Inventory/applications/compliance/SystemRulesTable.js
@@ -325,7 +325,7 @@ class SystemRulesTable extends React.Component {
                                 <Checkbox onChange={ this.hidePassed } label={ 'Hide Passed Rules' } />
                             </LevelItem>
                             <LevelItem>
-                                { rows.length } results
+                                { rows.length / 2 } results
                             </LevelItem>
                             <LevelItem>
                                 <ComplianceRemediationButton selectedRules={ this.selectedRules() } />


### PR DESCRIPTION
For each rule result, we have a header and description (which folds into
each header in the UI). This gives us 2X the rows, and the count needs
to be # of rows / 2.