### PR TITLE
Add templates for issue and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us fix a bug
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea or request a feature
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,19 @@
+---
+name: Bug fix
+about: Fixing a bug
+title: ""
+labels: bug
+assignees: ''
+
+---
+
+Fixes #
+
+**Screenshot of bug**
+If applicable, add screenshots of bug for comparison.
+
+**Screenshot of fix**
+If applicable, add screenshots to help explain your solution.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE/new_component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_component.md
@@ -1,0 +1,23 @@
+---
+name: New feature
+about: Suggest a solution for a feature
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Screenshot of feature**
+If applicable, add screenshots to help explain your solution.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Have you updated the documentation?**
+if not, please update at `src/doc/foo`
+
+**Have you updated the snapshots?**
+if not, please update the `foo.test.js` file and then run `npm run test -- -u`


### PR DESCRIPTION
This should allow issues and PRs to have more consistency across the board. If anyone has any other ideas or would like to update the docs, please leave comments and discuss. 