### PR TITLE
When active rule index is 0 ensure we display it first

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -85,7 +85,8 @@ class InventoryRuleList extends Component {
         const reports = activeReports;
         const activeRuleIndex = activeReports.findIndex(report => report.rule.rule_id === this.props.match.params.id);
         const activeReport = reports.splice(activeRuleIndex, 1);
-        return activeRuleIndex ? [ activeReport[0], ...reports ] : activeReports;
+
+        return activeRuleIndex !== -1 ? [ activeReport[0], ...reports ] : activeReports;
     }
 
     expandAll (expanded) {


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHIADVISOR-455

### look! it works! title and first rule match
<img width="1431" alt="screen shot 2019-03-01 at 10 27 03 am" src="https://user-images.githubusercontent.com/6640236/53648080-ffc6bf00-3c0c-11e9-8a28-5022ea67d96e.png">
