### PR TITLE
updating TableToolbar to use Toolbar layout <?.?.x>

### DIFF
--- a/doc/components/tableToolbar.md
+++ b/doc/components/tableToolbar.md
@@ -1,6 +1,6 @@
 # Table Toolbar
 
-Implementation of 'table toolbar' that can contain table actions
+Implementation of 'table toolbar' that can contain table actions. Simply a styled wrapper for Patternfly's Toolbar component
 
 ## Usage
 
@@ -8,13 +8,19 @@ Import TableToolbar and styles from this package.
 
 ```JSX
 import React from 'react';
-import { TableToolbar } from '@redhat-insights/insights-frontent-components/';
+import { TableToolbar } from '@redhat-insights/insights-frontent-components';
+import { ToolbarItem } from '@patternfly/react-core';
+
 
 class YourCmp extends React.Component {
   render() {
     return (
         <TableToolbar>
-            // Whatever content you want inside the toolbar (search, buttons, etc)
+            // Whatever content you want inside the toolbar (search, buttons, etc) can go in ToolbarItem
+            <ToolbarGroup>
+              <ToolbarItem> Foo </ToolbarItem>
+              <ToolbarItem> Bar </ToolbarItem>
+            </ToolbarGroup>
         </TableToolbar>
         <Table>
             // Table content

--- a/src/PresentationalComponents/TableToolbar/TableToolbar.js
+++ b/src/PresentationalComponents/TableToolbar/TableToolbar.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import propTypes from 'prop-types';
-
+import { Toolbar } from '@patternfly/react-core';
 import classNames from 'classnames';
 
 import './TableToolbar.scss';
@@ -22,7 +22,7 @@ const TableToolbar = ({ results, className, children, ...props }) => {
 
     return (
         <Fragment>
-            <div className={ tableToolbarClasses } { ...props }> { children }</div>
+            <Toolbar className={ tableToolbarClasses } { ...props }> { children }</Toolbar>
             {
                 results >= 0 &&
                 <div className='ins-c-table__toolbar-results'>

--- a/src/PresentationalComponents/TableToolbar/__snapshots__/TableToolbar.test.js.snap
+++ b/src/PresentationalComponents/TableToolbar/__snapshots__/TableToolbar.test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`TableToolbar component should render 1`] = `
 <Fragment>
-  <div
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </div>
+  </Toolbar>
 </Fragment>
 `;
 
 exports[`TableToolbar component should render with results greater than 1 1`] = `
 <Fragment>
-  <div
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </div>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -29,12 +29,12 @@ exports[`TableToolbar component should render with results greater than 1 1`] = 
 
 exports[`TableToolbar component should render with results of 0 1`] = `
 <Fragment>
-  <div
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </div>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -45,12 +45,12 @@ exports[`TableToolbar component should render with results of 0 1`] = `
 
 exports[`TableToolbar component should render with results of 1 1`] = `
 <Fragment>
-  <div
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </div>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >


### PR DESCRIPTION
Before, the TableToolbar just wrapped everything in a `<div>`, now this will just act as the "Toolbar" layout from Patternfly, just with additional styling.