### PR TITLE
Decouple from patternfly sass-utilities <?.x.?>

### DIFF
--- a/src/Utilities/_variables.scss
+++ b/src/Utilities/_variables.scss
@@ -1,5 +1,3 @@
-@import '~@patternfly/patternfly/sass-utilities/all';
-
 :root {
     --ins-color--orange: #ec7a08;
 }
@@ -20,11 +18,11 @@ $ins-borderRadius: var(--pf-global--BorderRadius--sm);
 $ins-borderRadius--round: var(--pf-global--BorderRadius--lg);
 
 // Grid breakpoints
-$ins-break--xs: $pf-global--breakpoint--xs;
-$ins-break--sm: $pf-global--breakpoint--sm;
-$ins-break--md: $pf-global--breakpoint--md;
-$ins-break--lg: $pf-global--breakpoint--lg;
-$ins-break--xl: $pf-global--breakpoint--xl;
+$ins-break--xs: var(--pf-global--breakpoint--xs);
+$ins-break--sm: var(---pf-global--breakpoint--sm);
+$ins-break--md: var(--pf-global--breakpoint--md);
+$ins-break--lg: var(--pf-global--breakpoint--lg);
+$ins-break--xl: var(--pf-global--breakpoint--xl);
 
 // Colors
 $ins-color--red: var(--pf-global--danger-color--100);

--- a/src/Utilities/_variables.scss
+++ b/src/Utilities/_variables.scss
@@ -19,7 +19,7 @@ $ins-borderRadius--round: var(--pf-global--BorderRadius--lg);
 
 // Grid breakpoints
 $ins-break--xs: var(--pf-global--breakpoint--xs);
-$ins-break--sm: var(---pf-global--breakpoint--sm);
+$ins-break--sm: var(--pf-global--breakpoint--sm);
 $ins-break--md: var(--pf-global--breakpoint--md);
 $ins-break--lg: var(--pf-global--breakpoint--lg);
 $ins-break--xl: var(--pf-global--breakpoint--xl);


### PR DESCRIPTION
Talked with @iphands about this a little yesterday.

My reasoning behind this is that right now, we depend on an app to have `@patternfly/patternfly` to import the sass utilities because we're using sass variables.

Instead, let's just provide the css vars namespaced differently if people want to use them. If `sass-utilities` are needed, then the app needs to download the package themselves.