### PR TITLE
Fixes RHICOMPL-106: remove extra whitespace in table toolbar

### DIFF
--- a/src/PresentationalComponents/TableToolbar/TableToolbar.scss
+++ b/src/PresentationalComponents/TableToolbar/TableToolbar.scss
@@ -2,7 +2,7 @@
 
 :root {
     --ins-c-table-toolbar--PaddingVertical: 16px;
-    --ins-c-table-toolbar--PaddingHorizontal: 32px;
+    --ins-c-table-toolbar--PaddingHorizontal: 0px;
 }
 
 .ins-c-table__toolbar, .ins-c-table__toolbar-results {

--- a/src/SmartComponents/Inventory/Filter/Filter.js
+++ b/src/SmartComponents/Inventory/Filter/Filter.js
@@ -120,7 +120,7 @@ class ContextFilter extends Component {
         const filteredColumns = columns && columns.filter(column => !column.isTime).map(this.textualFilter);
         const placeholder = filterByString || (filteredColumns && filteredColumns.length > 0 && filteredColumns[0].title);
         return (
-            <Grid guttter="sm" className="ins-inventory-filters">
+            <Grid gutter="sm" className="ins-inventory-filters">
                 {
                     (!hasItems && (total !== 0 || activeFilters.length !== 0)) &&
                     <GridItem span={ 4 } className="ins-inventory-text-filter">
@@ -158,20 +158,8 @@ class ContextFilter extends Component {
                         />
                     </GridItem>
                 }
-                <GridItem span={ hasItems ? 10 : 6 }>
+                <GridItem span={ 12 }>
                     { children }
-                </GridItem>
-                <GridItem span={ 1 } className="ins-inventory-total pf-u-display-flex pf-u-align-items-center">
-                    { total > 0 && <div>{ total } result{ total > 1 && 's' }</div> }
-                    { /* <Button
-                        variant="plain"
-                        className="ins-refresh"
-                        title="Refresh"
-                        aria-label="Refresh"
-                        onClick={ _event => onRefreshData() }
-                    >
-                        <SyncAltIcon />
-                    </Button> */ }
                 </GridItem>
             </Grid>
         );

--- a/src/SmartComponents/Inventory/InventoryList.js
+++ b/src/SmartComponents/Inventory/InventoryList.js
@@ -55,7 +55,7 @@ class ContextInventoryList extends React.Component {
         const { showHealth, ...props } = this.props;
         return (
             <React.Fragment>
-                <Grid guttter="sm" className="ins-inventory-list">
+                <Grid gutter="sm" className="ins-inventory-list">
                     <GridItem span={ 12 }>
                         <InventoryEntityTable { ...props } showHealth={ showHealth } />
                     </GridItem>


### PR DESCRIPTION
This completely removes the number of results at the top of the table. I'm not sure why that was part of the `Filter` component in the first place? The same information is still at the bottom of the table. It also aligns the download button with the side of the table and fixes the line above the table.

Before:

![image](https://user-images.githubusercontent.com/761923/54289093-f6c7dd00-457e-11e9-988c-0c2f576c8382.png)


After:

![image](https://user-images.githubusercontent.com/761923/54289039-d8fa7800-457e-11e9-9a0a-5d6d3d8a4b41.png)

I'm not sure what happened to the 'Remediate with Ansible' button. The patternfly docs suggest it should be pushed all the way to the right... https://patternfly-react.surge.sh/patternfly-4/layouts/level https://github.com/RedHatInsights/compliance-frontend/blob/master/src/SmartComponents/SystemsTable/SystemsTable.js#L57
