### PR TITLE
Insights api changed, report.resoution.has_playbook now, fixes kba fetch

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -30,7 +30,9 @@ class InventoryRuleList extends Component {
     }
 
     processRemediation (systemId, reports) {
-        const issues = reports.filter(r => r.rule.has_playbook).map(r => ({ id: `advisor:${r.rule.rule_id}`, description: r.rule.description }));
+        const issues = reports.filter(r => r.resolution.has_playbook).map(
+            r => ({ id: `advisor:${r.rule.rule_id}`, description: r.rule.description })
+        );
 
         return issues.length ?
             { issues, systems: [ systemId ]} :
@@ -41,7 +43,7 @@ class InventoryRuleList extends Component {
         const { entity } = this.props;
         try {
             await insights.chrome.auth.getUser();
-            const data = await fetch(`${SYSTEM_FETCH_URL}${entity.id}/reports`, { credentials: 'include' })
+            const data = await fetch(`${SYSTEM_FETCH_URL}${entity.id}/reports/`, { credentials: 'include' })
             .then(data => data.json()).catch(error => { throw error; });
             this.setState({
                 inventoryReport: data,
@@ -66,7 +68,7 @@ class InventoryRuleList extends Component {
 
     async fetchKbaDetails (kbaIds) {
         try {
-            const data = await fetch(`/rs/search?q=id:(${kbaIds})&fl=view_uri,id,publishedTitle`, { credentials: 'include' })
+            const data = await fetch(`https://access.redhat.com/rs/search?q=id:(${kbaIds})&fl=view_uri,id,publishedTitle`, { credentials: 'include' })
             .then(data => data.json());
             this.setState({
                 kbaDetails: data.response.docs

--- a/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
+++ b/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
@@ -78,7 +78,7 @@ class ExpandableRulesCard extends React.Component {
                         <SplitItem> { rule.category.name } &gt; </SplitItem>
                         <SplitItem isMain> { rule.description } </SplitItem>
                         <SplitItem>
-                            <Ansible unsupported={ !rule.has_playbook }/>
+                            <Ansible unsupported={ !report.resolution.has_playbook }/>
                         </SplitItem>
                     </Split>
                     <Section type='icon-group__with-major'>


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-503

this fixes the kba fetch issue, the thing that happened because we moved/moving to cloud.redhat

also fixes the move of the has_playbook off the rule and onto the report

### cuz fotos work well, first one shows a report with no playbook, properly indicated, second one shows kba success as well as, remediate button working again
<img width="1499" alt="Screen Shot 2019-03-25 at 9 43 18 AM" src="https://user-images.githubusercontent.com/6640236/54924505-f0245880-4ee2-11e9-9015-64f994cdaf98.png">
<img width="1498" alt="Screen Shot 2019-03-25 at 9 42 40 AM" src="https://user-images.githubusercontent.com/6640236/54924506-f0245880-4ee2-11e9-927f-9fc3def6d649.png">
