### PR TITLE
Inheriting whitespace on `code` fixes this issue

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/advisor.scss
+++ b/src/SmartComponents/Inventory/applications/advisor/advisor.scss
@@ -50,7 +50,7 @@
         background-color: #f5f5f5;
         border: 1px solid #ccc;
         border-radius: 4px;
-        code { white-space: normal; }
+        code { white-space: inherit; }
     }
 
     ol {


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-402 , https://bugzilla.redhat.com/show_bug.cgi?id=1686609

### tada
<img width="1069" alt="Screen Shot 2019-03-26 at 7 29 18 AM" src="https://user-images.githubusercontent.com/6640236/54994114-d6921800-4f99-11e9-972f-470f670be209.png">
