### PR TITLE
Removes fetch failed toast, adds no system text

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import connect from 'react-redux/es/connect/connect';
-import { addNotification } from '../../../Notifications';
 import '@patternfly/patternfly/utilities/Display/display.css';
 import '@patternfly/patternfly/utilities/Flex/flex.css';
 import { List } from 'react-content-loader';
@@ -54,15 +53,10 @@ class InventoryRuleList extends Component {
             const kbaIds = data.map(report => report.rule.node_id).join(` OR `);
             this.fetchKbaDetails(kbaIds);
         } catch (error) {
-            this.props.addNotification({
-                variant: 'danger',
-                dismissable: true,
-                title: 'Rules Error',
-                description: 'Inventory item rule fetch failed.'
-            });
             this.setState({
                 inventoryReportFetchStatus: 'failed'
             });
+            console.warn(error, 'Entity rules fetch failed.');
         }
     }
 
@@ -74,12 +68,7 @@ class InventoryRuleList extends Component {
                 kbaDetails: data.response.docs
             });
         } catch (error) {
-            this.props.addNotification({
-                variant: 'danger',
-                dismissable: true,
-                title: '',
-                description: 'KBA fetch failed.'
-            });
+            console.warn(error, 'KBA detail fetch failed.');
         }
     }
 
@@ -146,13 +135,22 @@ class InventoryRuleList extends Component {
                             </CardBody>
                         </Card>
                 ) }
-                { inventoryReportFetchStatus === 'failed' && (
+                { inventoryReportFetchStatus === 'failed' && this.props.entity && (
                     <Card className="ins-empty-rule-cards">
                         <CardHeader>
                             <FrownOpenIcon size='lg'/>
                         </CardHeader>
                         <CardBody>
                             There was an error fetching rules list for this Entity. Please show your administrator this screen.
+                        </CardBody>
+                    </Card>
+                ) }   { inventoryReportFetchStatus === 'failed' && !this.props.entity && (
+                    <Card className="ins-empty-rule-cards">
+                        <CardHeader>
+                            <FrownOpenIcon size='lg'/>
+                        </CardHeader>
+                        <CardBody>
+                            This system can not be found or might no longer be registered to Red Hat Insights.
                         </CardBody>
                     </Card>
                 ) }
@@ -171,11 +169,7 @@ const mapStateToProps = ({ entityDetails: { entity }}) => ({
     entity
 });
 
-const mapDispatchToProps = dispatch => ({
-    addNotification: data => dispatch(addNotification(data))
-});
-
 export default withRouter(connect(
     mapStateToProps,
-    mapDispatchToProps
+    null
 )(InventoryRuleList));


### PR DESCRIPTION
### new text!
<img width="1502" alt="Screen Shot 2019-04-12 at 9 20 21 AM" src="https://user-images.githubusercontent.com/6640236/56040535-973b2980-5d04-11e9-96b3-7cfe62faf4ff.png">

semi related to https://projects.engineering.redhat.com/browse/RHCLOUD-721

the case for this is lets say you share a url to someone and it doesn't exist, or that it just doesn't exist, or was recently removed (the system)