### PR TITLE
Disable default auto hiding notifications in notifications middleware.

### DIFF
--- a/src/SmartComponents/Notifications/notificationsMiddleware.js
+++ b/src/SmartComponents/Notifications/notificationsMiddleware.js
@@ -37,7 +37,7 @@ const createNotificationsMiddleware = (options = {}) => {
         pendingSuffix: '_PENDING',
         fulfilledSuffix: '_FULFILLED',
         rejectedSuffix: '_REJECTED',
-        autoDismiss: true,
+        autoDismiss: false,
         dismissDelay: 5000,
         errorTitleKey: 'title',
         errorDescriptionKey: 'detail'

--- a/src/SmartComponents/Notifications/notificationsMiddleware.test.js
+++ b/src/SmartComponents/Notifications/notificationsMiddleware.test.js
@@ -303,7 +303,8 @@ describe('Notifications middleware', () => {
         notifications: {
           rejected: {
             variant: 'warning',
-            title: 'custom error notification'
+            title: 'custom error notification',
+            dismissable: false,
           }
         }
       }


### PR DESCRIPTION
Insights UX designers requested to disable automatic hiding for notifications. This can be still enabled in notifications configuration on on each notification separately.

cc @karelhala 