### PR TITLE
Fix loading of incorrect entityDetail

### DIFF
--- a/src/SmartComponents/Inventory/InventoryDetail.js
+++ b/src/SmartComponents/Inventory/InventoryDetail.js
@@ -16,7 +16,8 @@ class InventoryDetail extends React.Component {
                 inventoryId,
                 {
                     prefix: this.props.pathPrefix,
-                    base: this.props.apiBase
+                    base: this.props.apiBase,
+                    hasItems: true
                 }
             );
         }


### PR DESCRIPTION
When user clicked a system from Inventory list he was redirected to correct URL, however wrong inventory_id was fetched. This PR fixes the issue. Reproduced and tested on Vulnerability app.