### PR TITLE
Regex replaces all instances, template literal (string) only 1st (ul instance)

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
+++ b/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
@@ -52,7 +52,7 @@ class ExpandableRulesCard extends React.Component {
             const compiledMd = marked(sanitizeHtml(compiledDot, sanitizeOptions));
 
             return <div dangerouslySetInnerHTML={ { __html: compiledMd
-            .replace(`<ul>`, `<ul class="pf-c-list">`)
+            .replace(/<ul>/gim, `<ul class="pf-c-list">`)
             .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`) } } />;
         } catch (error) {
             console.warn(error, definitions, template); // eslint-disable-line no-console


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-705

### now we're replacing all instances
<img width="1305" alt="Screen Shot 2019-04-29 at 8 52 59 AM" src="https://user-images.githubusercontent.com/6640236/56897423-87d61300-6a5c-11e9-9ca4-056fa2fc44c6.png">
<img width="1308" alt="Screen Shot 2019-04-29 at 8 52 49 AM" src="https://user-images.githubusercontent.com/6640236/56897424-87d61300-6a5c-11e9-9871-c777d3a8a886.png">
