### PR TITLE
Ensures rule hits remain whole when not consumed by insights

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -74,7 +74,7 @@ class InventoryRuleList extends Component {
     }
 
     sortActiveReports (activeReports) {
-        const reports = Object.assign({}, activeReports);
+        const reports = { ...activeReports };
         const activeRuleIndex = activeReports.findIndex(report => report.rule.rule_id === this.props.match.params.id);
         const activeReport = reports.splice(activeRuleIndex, 1);
 

--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -74,7 +74,7 @@ class InventoryRuleList extends Component {
     }
 
     sortActiveReports (activeReports) {
-        const reports = activeReports;
+        const reports = Object.assign({}, activeReports);
         const activeRuleIndex = activeReports.findIndex(report => report.rule.rule_id === this.props.match.params.id);
         const activeReport = reports.splice(activeRuleIndex, 1);
 


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1117

tl;dr splice mutates the original array. 👻 🐍 👎 

if  you do something like `reports.splice(-1, 1);` (which is what happens when we don't find an active report), you lose the last entry from the list, which is what we see in inventory app 😭 