### PR TITLE
Allow to pass cvvs_filter in URL params to Vulnerability

### DIFF
--- a/src/SmartComponents/Inventory/applications/vulnerabilities/VulnerabilitiesCveTableToolbar.js
+++ b/src/SmartComponents/Inventory/applications/vulnerabilities/VulnerabilitiesCveTableToolbar.js
@@ -18,7 +18,12 @@ class VulnerabilitiesCveTableToolbar extends Component {
 
     componentDidMount() {
         this.props.entity && this.props.fetchStatusList();
+        const urlParams = new URLSearchParams(this.props.location.search);
+        const cvss_filter = urlParams.get('cvss_filter');
+        cvss_filter && this.setState({ ...this.state, cvss_filter }, this.apply);
+        cvss_filter && history.pushState(null, null, window.location.href.split('?')[0]);
     }
+
     changeFilterValue = debounce(
         value =>
             this.setState(
@@ -172,7 +177,8 @@ VulnerabilitiesCveTableToolbar.propTypes = {
     addNotification: propTypes.func.isRequired,
     selectedCves: propTypes.any,
     fetchStatusList: propTypes.func,
-    statusList: propTypes.object
+    statusList: propTypes.object,
+    location: propTypes.object
 };
 
 VulnerabilitiesCveTableToolbar.defaultProps = {


### PR DESCRIPTION
Dashboard has a link to Vulnerability that should redirect user to a filtered CVE table by CVSS_Score. This should make it possible by passing "cvss_filter" accepting values from predefined ranges (as PF does not have a slider component, there need to be predefined ranges). This URL parameter is then removed so it does not confuse the user as he would continue filtering.