### PR TITLE
Replaces the kbafetch with static `node/${report.rule.node_id}`

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/Advisor.js
+++ b/src/SmartComponents/Inventory/applications/advisor/Advisor.js
@@ -21,7 +21,6 @@ class InventoryRuleList extends Component {
         inventoryReportFetchStatus: 'pending',
         inventoryReport: {},
         activeReports: [],
-        kbaDetails: [],
         remediation: false
     };
 
@@ -51,25 +50,11 @@ class InventoryRuleList extends Component {
                 inventoryReportFetchStatus: 'fulfilled',
                 remediation: this.processRemediation(entity.id, data)
             });
-            const kbaIds = data.map(report => report.rule.node_id).join(` OR `);
-            this.fetchKbaDetails(kbaIds);
         } catch (error) {
             this.setState({
                 inventoryReportFetchStatus: 'failed'
             });
             console.warn(error, 'Entity rules fetch failed.');
-        }
-    }
-
-    async fetchKbaDetails (kbaIds) {
-        try {
-            const data = await fetch(`https://access.redhat.com/rs/search?q=id:(${kbaIds})&fl=view_uri,id,publishedTitle`, { credentials: 'include' })
-            .then(data => data.json());
-            this.setState({
-                kbaDetails: data.response.docs
-            });
-        } catch (error) {
-            console.warn(error, 'KBA detail fetch failed.');
         }
     }
 
@@ -79,14 +64,14 @@ class InventoryRuleList extends Component {
         const activeReport = reports.splice(activeRuleIndex, 1);
 
         return activeRuleIndex !== -1 ? [ activeReport[0], ...reports ] : activeReports;
-    }
+    };
 
     expandAll (expanded) {
         this.setState({ expanded: !expanded });
     }
 
     buildRuleCards = () => {
-        const { activeReports, expanded, kbaDetails, remediation } = this.state;
+        const { activeReports, expanded, remediation } = this.state;
 
         return (
             <Fragment>
@@ -103,12 +88,12 @@ class InventoryRuleList extends Component {
                         <RemediationButton
                             isDisabled={ !remediation }
                             dataProvider={ () => remediation }
-                            onRemediationCreated={ result => this.props.addNotification(result.getNotification()) } />
+                            onRemediationCreated={ result => this.props.addNotification(result.getNotification()) }/>
                     </LevelItem>
                 </Level>
                 {
                     activeReports && activeReports.map((report, key) =>
-                        <ExpandableRulesCard key={ key } report={ report } isExpanded={ expanded } kbaDetails={ kbaDetails }/>
+                        <ExpandableRulesCard key={ key } report={ report } isExpanded={ expanded }/>
                     ) }
             </Fragment>
         );
@@ -145,13 +130,13 @@ class InventoryRuleList extends Component {
                             There was an error fetching rules list for this Entity. Please show your administrator this screen.
                         </CardBody>
                     </Card>
-                ) }   { inventoryReportFetchStatus === 'failed' && !this.props.entity && (
+                ) } { inventoryReportFetchStatus === 'failed' && !this.props.entity && (
                     <Card className="ins-empty-rule-cards">
                         <CardHeader>
                             <FrownOpenIcon size='lg'/>
                         </CardHeader>
                         <CardBody>
-                            This system can not be found or might no longer be registered to Red Hat Insights.
+                        This system can not be found or might no longer be registered to Red Hat Insights.
                         </CardBody>
                     </Card>
                 ) }

--- a/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
+++ b/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
@@ -15,19 +15,12 @@ import './advisor.scss';
 
 class ExpandableRulesCard extends React.Component {
     state = {
-        expanded: true,
-        kbaDetail: {}
+        expanded: true
     };
 
     componentDidUpdate (prevProps) {
         if (this.props.isExpanded !== prevProps.isExpanded) {
             this.setState({ expanded: this.props.isExpanded });
-        }
-
-        if (this.props.kbaDetails !== prevProps.kbaDetails) {
-            this.setState({
-                kbaDetail: this.props.kbaDetails.filter(article => article.id === this.props.report.rule.node_id)[0]
-            });
         }
     }
 
@@ -51,9 +44,11 @@ class ExpandableRulesCard extends React.Component {
             const compiledDot = definitions ? doT.template(template, DOT_SETTINGS)(definitions) : template;
             const compiledMd = marked(sanitizeHtml(compiledDot, sanitizeOptions));
 
-            return <div dangerouslySetInnerHTML={ { __html: compiledMd
-            .replace(/<ul>/gim, `<ul class="pf-c-list">`)
-            .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`) } } />;
+            return <div dangerouslySetInnerHTML={ {
+                __html: compiledMd
+                .replace(/<ul>/gim, `<ul class="pf-c-list">`)
+                .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`)
+            } }/>;
         } catch (error) {
             console.warn(error, definitions, template); // eslint-disable-line no-console
             return <React.Fragment> Ouch. We were unable to correctly render this text, instead please enjoy the raw data.
@@ -65,7 +60,7 @@ class ExpandableRulesCard extends React.Component {
     render () {
         const { report } = this.props;
         const rule = report.rule || report;
-        const { expanded, kbaDetail } = this.state;
+        const { expanded } = this.state;
         let rulesCardClasses = classNames(
             'ins-c-inventory-advisor__card',
             'ins-c-rules-card'
@@ -114,13 +109,15 @@ class ExpandableRulesCard extends React.Component {
                                 </CardBody>
                             </Card>
                         </StackItem>
-                        { kbaDetail && kbaDetail.view_uri && <StackItem>
+                        { report.rule.node_id && <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
                                     <LightbulbIcon/><strong>Related Knowledgebase articles: </strong>
                                 </CardHeader>
                                 <CardBody>
-                                    <a href={ `${kbaDetail.view_uri}` } rel="noopener">`${ kbaDetail.publishedTitle } <ExternalLinkAltIcon />`</a>
+                                    <a rel="noopener noreferrer" target="_blank" href={ `https://access.redhat.com/node/${report.rule.node_id}` }>
+                                        Knowledgebase Article <ExternalLinkAltIcon size='sm'/>
+                                    </a>
                                 </CardBody>
                             </Card>
                         </StackItem> }
@@ -129,15 +126,15 @@ class ExpandableRulesCard extends React.Component {
                             <List>
                                 <ListItem>
                                     { `To learn how to upgrade packages, see ` }<a href="https://access.redhat.com/solutions/9934" rel="noopener">
-                                         What is yum and how do I use it? <ExternalLinkAltIcon />
+                                    What is yum and how do I use it? <ExternalLinkAltIcon/>
                                     </a>{ `.` }
                                 </ListItem>
                                 <ListItem>{ `The Customer Portal page for the ` }
-                                    <a href="https://access.redhat.com/security/" rel="noopener">Red Hat Security Team <ExternalLinkAltIcon /></a>
+                                    <a href="https://access.redhat.com/security/" rel="noopener">Red Hat Security Team <ExternalLinkAltIcon/></a>
                                     { ` contains more information about policies, procedures, and alerts for Red Hat Products.` }
                                 </ListItem>
                                 <ListItem>{ `The Security Team also maintains a frequently updated blog at ` }
-                                    <a href="https://securityblog.redhat.com" rel="noopener">securityblog.redhat.com <ExternalLinkAltIcon /></a>.
+                                    <a href="https://securityblog.redhat.com" rel="noopener">securityblog.redhat.com <ExternalLinkAltIcon/></a>.
                                 </ListItem>
                             </List>
                         </div>
@@ -152,12 +149,10 @@ export default ExpandableRulesCard;
 
 ExpandableRulesCard.defaultProps = {
     report: {},
-    isExpanded: true,
-    kbaDetails: []
+    isExpanded: true
 };
 
 ExpandableRulesCard.propTypes = {
     report: propTypes.object,
-    isExpanded: propTypes.bool,
-    kbaDetails: propTypes.array
+    isExpanded: propTypes.bool
 };


### PR DESCRIPTION
Similar to https://github.com/RedHatInsights/insights-advisor-frontend/pull/316 but what we lose is article title on the link... what we save is making yet another external call... need ux input on this, it says "articles" but we only ever display an article, (this is a carry over from classic)



### what it looks like
<img width="1393" alt="Screen Shot 2019-05-07 at 1 30 07 PM" src="https://user-images.githubusercontent.com/6640236/57321149-b1cbad00-70ce-11e9-801a-45c28a5dde31.png">



(kinda) fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1195