### PR TITLE
Ensures advisor static list inherits font-size as well

### DIFF
--- a/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
+++ b/src/SmartComponents/Inventory/applications/advisor/ExpandableRulesCard.js
@@ -141,7 +141,7 @@ class ExpandableRulesCard extends React.Component {
                                 </CardHeader>
                                 <CardBody>
                                     { rule.more_info && this.templateProcessor(rule.more_info) }
-                                    <List>
+                                    <List style={ { fontSize: 'inherit' } }>
                                         <ListItem>
                                             { `To learn how to upgrade packages, see ` }<a href="https://access.redhat.com/solutions/9934"
                                                 rel="noopener">


### PR DESCRIPTION
<img width="1064" alt="Screen Shot 2019-05-13 at 8 33 04 AM" src="https://user-images.githubusercontent.com/6640236/57621704-23d24500-755a-11e9-981d-b1186d893708.png">
